### PR TITLE
change sklearn to scikit-learn

### DIFF
--- a/meshpy/setup.py
+++ b/meshpy/setup.py
@@ -18,7 +18,7 @@ class PostInstallCmd(install):
 requirements = [
     'numpy',
     'scipy',
-    'sklearn',
+    'scikit-learn',
     'Pillow',
 ]
 


### PR DESCRIPTION
Running `python setup.py develop` in `meshpy` fails because of the sklearn pypi deprecation. This fixes it.